### PR TITLE
 Add support for specifying GCP instances

### DIFF
--- a/main.go
+++ b/main.go
@@ -74,7 +74,7 @@ Environment variables:
 More info: https://github.com/cdr/sshcode
 
 Arguments:
-%vHOST is passed into the ssh command.
+%vHOST is passed into the ssh command. Valid formats are '<ip-address>' or 'gcp:<instance-name>'. 
 %vDIR is optional.
 
 %v`,

--- a/sshcode_test.go
+++ b/sshcode_test.go
@@ -261,7 +261,7 @@ func waitForSSHCode(t *testing.T, port string, timeout time.Duration) {
 	}
 }
 
-// fakeRSAKey isn't used for anything other than the trashh ssh
+// fakeRSAKey isn't used for anything other than the trassh ssh
 // server.
 const fakeRSAKey = `-----BEGIN RSA PRIVATE KEY-----
 MIIEpQIBAAKCAQEAsbbGAxPQeqti2OgdzuMgJGBAwXe/bFhQTPuk0bIvavkZwX/a


### PR DESCRIPTION
- Specifying 'gcp:<instance-name>' for the host argument is now
  supported for indicating a Google Cloud compute instance

resolves #2 