### PR TITLE
Some updates for document

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,3 +86,18 @@ export VSCODE_EXTENSIONS_DIR="$HOME/.vscode-insiders/extensions"
 By default, VS Code changes on the remote server won't be synced back
 when the connection closes. To synchronize back to local when the connection ends,
 pass the `-b` flag.
+
+
+### Auto open in browser trouble shooting
+
+sshcode detects if you're under GUI mode via checking environment variable `DISPLAY`.
+If `DISPLAY` is not empty, then it will try to open romote vscode url in browser app mode.
+
+But the `DISPLAY` environment variable will only be set with X-Window installed.
+
+For OS doesn't have X-Window installed (e.g.: MacOS),
+export following environment variable for enabling auto open in browser feature.
+
+```bash
+export DISPLAY=":0"
+```

--- a/README.md
+++ b/README.md
@@ -86,18 +86,3 @@ export VSCODE_EXTENSIONS_DIR="$HOME/.vscode-insiders/extensions"
 By default, VS Code changes on the remote server won't be synced back
 when the connection closes. To synchronize back to local when the connection ends,
 pass the `-b` flag.
-
-
-### Auto open in browser trouble shooting
-
-sshcode detects if you're under GUI mode via checking environment variable `DISPLAY`.
-If `DISPLAY` is not empty, then it will try to open romote vscode url in browser app mode.
-
-But the `DISPLAY` environment variable will only be set with X-Window installed.
-
-For OS doesn't have X-Window installed (e.g.: MacOS),
-export following environment variable for enabling auto open in browser feature.
-
-```bash
-export DISPLAY=":0"
-```

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ sshcode kyle@dev.kwc.io
 You can specify a remote directory as the second argument:
 
 ```bash
-sshcode kyle@dev.kwc.io ~/projects/sourcegraph
+sshcode kyle@dev.kwc.io "~/projects/sourcegraph"
 ```
 
 ## Extensions & Settings Sync


### PR DESCRIPTION
1. `remote directory` parameter MUST be quoted on some OS (like MacOS)
2. OS has no X-window installed (like MacOS) need to set a fake DISPLAY env variable for enabling the auto open in browser feature.