### PR TITLE
Revert behavior using DISPLAY to open app window

### DIFF
--- a/sshcode.go
+++ b/sshcode.go
@@ -24,6 +24,7 @@ const codeServerPath = "~/.cache/sshcode/sshcode-server"
 type options struct {
 	skipSync   bool
 	syncBack   bool
+	noOpen     bool
 	localPort  string
 	remotePort string
 	sshFlags   string
@@ -130,7 +131,7 @@ func sshCode(host, dir string, o options) error {
 
 	ctx, cancel = context.WithCancel(context.Background())
 
-	if os.Getenv("DISPLAY") != "" {
+	if !o.noOpen {
 		openBrowser(url)
 	}
 

--- a/sshcode_test.go
+++ b/sshcode_test.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"net"
 	"net/http"
-	"os"
 	"os/exec"
 	"path/filepath"
 	"strconv"
@@ -20,10 +19,6 @@ import (
 )
 
 func TestSSHCode(t *testing.T) {
-	// Avoid opening a browser window.
-	err := os.Unsetenv("DISPLAY")
-	require.NoError(t, err)
-
 	sshPort, err := randomPort()
 	require.NoError(t, err)
 
@@ -44,6 +39,7 @@ func TestSSHCode(t *testing.T) {
 			sshFlags:   testSSHArgs(sshPort),
 			localPort:  localPort,
 			remotePort: remotePort,
+			noOpen:     true,
 		})
 		require.NoError(t, err)
 	}()


### PR DESCRIPTION
- Previously the DISPLAY environment variable was consulted when
  determining whether to open a browser app window. However, it appears
  the environment variable isn't set in some supported environments, so
  the behavior has been updating to always open a window.