### PR TITLE
add x86_64 check in downloadScript

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,11 @@ We currently support:
 - MacOS
 - WSL
 
+For the remote server, we currently only support Linux `x86_64` (64-bit)
+servers with `glibc`. `musl` libc (which is most notably used by Alpine Linux)
+is currently not supported on the remote server:
+[#122](https://github.com/cdr/sshcode/issues/122).
+
 ## Usage
 
 ```bash

--- a/sshcode.go
+++ b/sshcode.go
@@ -345,6 +345,7 @@ func downloadScript(codeServerPath string) string {
 	return fmt.Sprintf(
 		`set -euxo pipefail || exit 1
 
+[ "$(uname -m)" != "x86_64" ] && echo "Unsupported server architecture $(uname -m). code-server only has releases for x86_64 systems." && exit 1
 pkill -f %v || true
 mkdir -p ~/.local/share/code-server %v
 cd %v


### PR DESCRIPTION
Adds a check to the download script to make sure the output of `uname -m` is `x86_64` as code-server doesn't have releases for other platforms. If the architecture isn't supported you get output similar to the following:

```
go run . --skipsync fuyumi
2019-05-27 16:15:49 INFO	ensuring code-server is updated...
++ uname -m
+ '[' i686 != x86_64 ']'
++ uname -m
Unsupported server architecture i686. code-server only has releases for x86_64 systems.
+ echo 'Unsupported server architecture i686. code-server only has releases for x86_64 systems.'
+ exit 1
2019-05-27 16:15:50 FATAL	error: failed to update code-server:
---ssh cmd---
ssh  fuyumi /bin/bash
---download script---
set -euxo pipefail || exit 1

[ "$(uname -m)" != "x86_64" ] && echo "Unsupported server architecture $(uname -m). code-server only has releases for x86_64 systems." && exit 1
pkill -f ~/.cache/sshcode/sshcode-server || true
mkdir -p ~/.local/share/code-server ~/.cache/sshcode
cd ~/.cache/sshcode
wget -N https://codesrv-ci.cdr.sh/latest-linux
[ -f ~/.cache/sshcode/sshcode-server ] && rm ~/.cache/sshcode/sshcode-server
ln latest-linux ~/.cache/sshcode/sshcode-server
chmod +x ~/.cache/sshcode/sshcode-server: exit status 1
exit status 1
```

Closes #92.