### PR TITLE
Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ vendor
 bin
 .vscode
 sshcode
+sshcode.exe

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ We currently support:
 - Linux
 - MacOS
 - WSL
+- Windows Git Bash (MINGW64) - Requires [rsynch for Windows](http://repo.msys2.org/msys/x86_64/rsync-3.1.3-1-x86_64.pkg.tar.xz)
 
 ## Usage
 

--- a/main.go
+++ b/main.go
@@ -5,6 +5,9 @@ import (
 	"fmt"
 	"math/rand"
 	"os"
+	"os/user"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
@@ -75,6 +78,12 @@ func (c *rootCmd) Run(fl *flag.FlagSet) {
 		dir = "~"
 	}
 
+	// Get linux relative path if on windows
+	if runtime.GOOS == "windows" {
+		dir = relativeWindowsPath(dir)
+		fmt.Printf("relative path is %s\n", dir)
+	}
+
 	err := sshCode(host, dir, options{
 		skipSync: c.skipSync,
 		sshFlags: c.sshFlags,
@@ -108,4 +117,19 @@ Arguments:
 		helpTab,
 		helpTab,
 	)
+}
+
+func relativeWindowsPath(dir string) string {
+	fmt.Printf("Received '%s'\n", dir)
+	usr, err := user.Current()
+	if err != nil {
+		fmt.Printf("Could not get user: %v", err)
+		return dir
+	}
+	rel, err := filepath.Rel(usr.HomeDir, dir)
+	if err != nil {
+		return dir
+	}
+	rel = "~/" + filepath.ToSlash(rel)
+	return rel
 }

--- a/main.go
+++ b/main.go
@@ -133,3 +133,9 @@ func relativeWindowsPath(dir string) string {
 	rel = "~/" + filepath.ToSlash(rel)
 	return rel
 }
+
+func gitbashWindowsDir(dir string) (res string) {
+	res = filepath.ToSlash(dir)
+	res = "/" + strings.Replace(res, ":", "", -1)
+	return res
+}

--- a/settings.go
+++ b/settings.go
@@ -25,7 +25,8 @@ func configDir() (string, error) {
 	case "darwin":
 		path = os.ExpandEnv("$HOME/Library/Application Support/Code/User/")
 	case "windows":
-		path = "$HOME/.config/Code/User/"
+		// Can't use the filepath.Clean function to keep Linux format path that works well with gitbash
+		return gitbashWindowsDir(os.ExpandEnv("$HOME/.config/Code/User")), nil
 	default:
 		return "", xerrors.Errorf("unsupported platform: %s", runtime.GOOS)
 	}
@@ -42,7 +43,8 @@ func extensionsDir() (string, error) {
 	case "linux", "darwin":
 		path = os.ExpandEnv("$HOME/.vscode/extensions/")
 	case "windows":
-		path = "$HOME/.vscode/extensions/"
+		// Can't use the filepath.Clean function to keep Linux format path that works well with gitbash
+		return gitbashWindowsDir(os.ExpandEnv("$HOME/.vscode/extensions")), nil
 	default:
 		return "", xerrors.Errorf("unsupported platform: %s", runtime.GOOS)
 	}

--- a/settings.go
+++ b/settings.go
@@ -24,6 +24,8 @@ func configDir() (string, error) {
 		path = os.ExpandEnv("$HOME/.config/Code/User/")
 	case "darwin":
 		path = os.ExpandEnv("$HOME/Library/Application Support/Code/User/")
+	case "windows":
+		path = "$HOME/.config/Code/User/"
 	default:
 		return "", xerrors.Errorf("unsupported platform: %s", runtime.GOOS)
 	}
@@ -39,6 +41,8 @@ func extensionsDir() (string, error) {
 	switch runtime.GOOS {
 	case "linux", "darwin":
 		path = os.ExpandEnv("$HOME/.vscode/extensions/")
+	case "windows":
+		path = "$HOME/.vscode/extensions/"
 	default:
 		return "", xerrors.Errorf("unsupported platform: %s", runtime.GOOS)
 	}

--- a/sshcode.go
+++ b/sshcode.go
@@ -56,9 +56,9 @@ func sshCode(host, dir string, o options) error {
 	dlScript := downloadScript(codeServerPath)
 
 	// Downloads the latest code-server and allows it to be executed.
-	sshCmdStr := fmt.Sprintf("ssh %v %v /bin/bash", o.sshFlags, host)
+	sshCmdStr := fmt.Sprintf("ssh %v %v /bin/bash -l", o.sshFlags, host)
 
-	sshCmd := exec.Command("sh", "-c", sshCmdStr)
+	sshCmd := exec.Command("sh", "-l", "-c", sshCmdStr)
 	sshCmd.Stdout = os.Stdout
 	sshCmd.Stderr = os.Stderr
 	sshCmd.Stdin = strings.NewReader(dlScript)
@@ -353,8 +353,8 @@ wget -N https://codesrv-ci.cdr.sh/latest-linux
 ln latest-linux %v
 chmod +x %v`,
 		codeServerPath,
-		filepath.Dir(codeServerPath),
-		filepath.Dir(codeServerPath),
+		filepath.ToSlash(filepath.Dir(codeServerPath)),
+		filepath.ToSlash(filepath.Dir(codeServerPath)),
 		codeServerPath,
 		codeServerPath,
 		codeServerPath,


### PR DESCRIPTION
- Adds support for Windows when using Windows Git bash
- Translates relative path on Windows to the Linux SSH host
- This PR also solves #74 as far as proxy is set at `.profile`