### PR TITLE
Update --bind flag help text

### DIFF
--- a/main.go
+++ b/main.go
@@ -53,7 +53,7 @@ func (c *rootCmd) RegisterFlags(fl *flag.FlagSet) {
 	fl.BoolVar(&c.skipSync, "skipsync", false, "skip syncing local settings and extensions to remote host")
 	fl.BoolVar(&c.syncBack, "b", false, "sync extensions back on termination")
 	fl.BoolVar(&c.printVersion, "version", false, "print version information and exit")
-	fl.StringVar(&c.bindAddr, "bind", "", "local bind address for ssh tunnel")
+	fl.StringVar(&c.bindAddr, "bind", "", `local bind address for ssh tunnel, in [HOST]:PORT syntax (default: 127.0.0.1)`)
 	fl.StringVar(&c.sshFlags, "ssh-flags", "", "custom SSH flags")
 }
 

--- a/main.go
+++ b/main.go
@@ -53,7 +53,7 @@ func (c *rootCmd) RegisterFlags(fl *flag.FlagSet) {
 	fl.BoolVar(&c.skipSync, "skipsync", false, "skip syncing local settings and extensions to remote host")
 	fl.BoolVar(&c.syncBack, "b", false, "sync extensions back on termination")
 	fl.BoolVar(&c.printVersion, "version", false, "print version information and exit")
-	fl.StringVar(&c.bindAddr, "bind", "", `local bind address for ssh tunnel, in [HOST]:PORT syntax (default: 127.0.0.1)`)
+	fl.StringVar(&c.bindAddr, "bind", "", "local bind address for ssh tunnel, in [HOST]:PORT syntax (default: 127.0.0.1)")
 	fl.StringVar(&c.sshFlags, "ssh-flags", "", "custom SSH flags")
 }
 

--- a/main.go
+++ b/main.go
@@ -53,7 +53,7 @@ func (c *rootCmd) RegisterFlags(fl *flag.FlagSet) {
 	fl.BoolVar(&c.skipSync, "skipsync", false, "skip syncing local settings and extensions to remote host")
 	fl.BoolVar(&c.syncBack, "b", false, "sync extensions back on termination")
 	fl.BoolVar(&c.printVersion, "version", false, "print version information and exit")
-	fl.StringVar(&c.bindAddr, "bind", "", "local bind address for ssh tunnel, in [HOST]:PORT syntax (default: 127.0.0.1)")
+	fl.StringVar(&c.bindAddr, "bind", "", "local bind address for SSH tunnel, in [HOST][:PORT] syntax (default: 127.0.0.1)")
 	fl.StringVar(&c.sshFlags, "ssh-flags", "", "custom SSH flags")
 }
 

--- a/sshcode.go
+++ b/sshcode.go
@@ -168,8 +168,8 @@ func sshCode(host, dir string, o options) error {
 }
 
 func parseBindAddr(bindAddr string) (string, error) {
-	if bindAddr == "" {
-		bindAddr = ":"
+	if !strings.Contains(bindAddr, ":") {
+		bindAddr += ":"
 	}
 
 	host, port, err := net.SplitHostPort(bindAddr)


### PR DESCRIPTION
Clarify how to specify `--bind` without a host by providing the full syntax for it.

Closes #110.