### PR TITLE
Use the username provided in GCP address to ssh

### DIFF
--- a/sshcode.go
+++ b/sshcode.go
@@ -564,5 +564,5 @@ func parseGCPSSHCmd(instance string) (ip, sshFlags string, err error) {
 		return "", "", xerrors.Errorf("parsed invalid ip address %v", ip)
 	}
 
-	return ip, sshFlags, nil
+	return strings.TrimSpace(userIP), sshFlags, nil
 }

--- a/sshcode.go
+++ b/sshcode.go
@@ -552,17 +552,6 @@ func parseGCPSSHCmd(instance string) (ip, sshFlags string, err error) {
 
 	// E.g. foo@1.2.3.4.
 	userIP := toks[len(toks)-1]
-	toks = strings.Split(userIP, "@")
-	// Assume the '<user>@' is missing.
-	if len(toks) < 2 {
-		ip = strings.TrimSpace(toks[0])
-	} else {
-		ip = strings.TrimSpace(toks[1])
-	}
-
-	if net.ParseIP(ip) == nil {
-		return "", "", xerrors.Errorf("parsed invalid ip address %v", ip)
-	}
 
 	return strings.TrimSpace(userIP), sshFlags, nil
 }


### PR DESCRIPTION
Earlier if the user did something like this: 
```localUser@localhost:~$ sshcode gcp:userName@InstanceName```
it'd still be ssh as localUser@InstanceName , thats because only IP was returned and when that's the case, ssh tries to use the current username for remote machine, 
This fixes that.
Tested on my machine(Manjaro Linux).

Signed-off-by: Sahil Soni <SscSPs@gmail.com>