### PR TITLE
MSYS/MINGW Client Support (FINNALLY Working)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ vendor
 bin
 .vscode
 sshcode
+sshcode.exe

--- a/README.md
+++ b/README.md
@@ -13,10 +13,7 @@ What KINDA works (Requires user to do some stuff)
 * VSCode SyncBack <> It will use the DEFAULT paths to store VS code information on windows
 ### TODO
 [ ] Detect Windows seperate from `msys`/`mingw` (Probably going to check for unix variables.)
-[] Add windows support (IE: `C:\` file paths )
 
-
-___
 # sshcode
 
 [!["Open Issues"](https://img.shields.io/github/issues-raw/cdr/sshcode.svg)](https://github.com/cdr/sshcode/issues)

--- a/README.md
+++ b/README.md
@@ -1,19 +1,3 @@
-## Merith-TK `sshcode` Fork
-___
-This fork is specifically for getting `sshcode` to work within the `msys`/`MinGW` enviroment
-
-What currently works, 
-* pretty much everything you would expect if you dont have chrome installed, starts the reverse proxy server, opens default browser.
-
-What doesnt work
-* Chrome support, cannot test as i dont use chrome.
-
-What KINDA works (Requires user to do some stuff)
-* SyncBack??? <> Basically, you need rsync installed, just like on linux
-* VSCode SyncBack <> It will use the DEFAULT paths to store VS code information on windows
-### TODO
-[ ] Detect Windows seperate from `msys`/`mingw` (Probably going to check for unix variables.)
-
 # sshcode
 
 [!["Open Issues"](https://img.shields.io/github/issues-raw/cdr/sshcode.svg)](https://github.com/cdr/sshcode/issues)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,22 @@
+## Merith-TK `sshcode` Fork
+___
+This fork is specifically for getting `sshcode` to work within the `msys`/`MinGW` enviroment
+
+What currently works, 
+* pretty much everything you would expect if you dont have chrome installed, starts the reverse proxy server, opens default browser.
+
+What doesnt work
+* Chrome support, cannot test as i dont use chrome.
+
+What KINDA works (Requires user to do some stuff)
+* SyncBack??? <> Basically, you need rsync installed, just like on linux
+* VSCode SyncBack <> It will use the DEFAULT paths to store VS code information on windows
+### TODO
+[ ] Detect Windows seperate from `msys`/`mingw` (Probably going to check for unix variables.)
+[] Add windows support (IE: `C:\` file paths )
+
+
+___
 # sshcode
 
 [!["Open Issues"](https://img.shields.io/github/issues-raw/cdr/sshcode.svg)](https://github.com/cdr/sshcode/issues)

--- a/main.go
+++ b/main.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"math/rand"
 	"os"
-	"os/user"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -82,7 +81,7 @@ func (c *rootCmd) Run(fl *flag.FlagSet) {
 
 	// Get linux relative path if on windows
 	if runtime.GOOS == "windows" {
-		dir = relativeWindowsPath(dir)
+		dir = gitbashWindowsDir(dir)
 	}
 
 	err := sshCode(host, dir, options{
@@ -121,24 +120,28 @@ Arguments:
 	)
 }
 
-func relativeWindowsPath(dir string) string {
-	usr, err := user.Current()
-	if err != nil {
-		flog.Error("Could not get user: %v", err)
-		return dir
-	}
-	rel, err := filepath.Rel(usr.HomeDir, dir)
-	if err != nil {
-		return dir
-	}
-	rel = "~/" + filepath.ToSlash(rel)
-	return rel
-}
+//func relativeWindowsPath(dir string) string {
+//	usr, err := user.Current()
+//	if err != nil {
+//		flog.Error("Could not get user: %v", err)
+//		return dir
+//	}
+//	rel, err := filepath.Rel(usr.HomeDir, dir)
+//	if err != nil {
+//		return dir
+//	}
+//	rel = "~/" + filepath.ToSlash(rel)
+//	return rel
+//}
 
-// gitbashWindowsDir translates a directory similar to `C:\Users\username\path` to `~/path` for compatibility with Git bash.
+//This section translates a windows path such as "C:\Users\user" to "\Users\user"
+//AND removes the default paths for mingw and git4windows to fix specifying a file path breaking
 func gitbashWindowsDir(dir string) (res string) {
 	res = filepath.ToSlash(dir)
 	res = strings.Replace(res, "C:", "", -1)
-	//res2 =
+
+	// "/msys" is the default path for my setup, REMOVE BEFORE PUSH
+	res = strings.Replace(res, "/msys", "", -1)
+	res = strings.Replace(res, "/ming64", "", -1)
 	return res
 }

--- a/main.go
+++ b/main.go
@@ -120,28 +120,13 @@ Arguments:
 	)
 }
 
-//func relativeWindowsPath(dir string) string {
-//	usr, err := user.Current()
-//	if err != nil {
-//		flog.Error("Could not get user: %v", err)
-//		return dir
-//	}
-//	rel, err := filepath.Rel(usr.HomeDir, dir)
-//	if err != nil {
-//		return dir
-//	}
-//	rel = "~/" + filepath.ToSlash(rel)
-//	return rel
-//}
-
 //This section translates a windows path such as "C:\Users\user" to "\Users\user"
 //AND removes the default paths for mingw and git4windows to fix specifying a file path breaking
 func gitbashWindowsDir(dir string) (res string) {
 	res = filepath.ToSlash(dir)
 	res = strings.Replace(res, "C:", "", -1)
 
-	// "/msys" is the default path for my setup, REMOVE BEFORE PUSH
-	res = strings.Replace(res, "/msys", "", -1)
-	res = strings.Replace(res, "/ming64", "", -1)
+	// If you dont use "C:\mingw64" as the location where you installed mingw, cop this and replace /mingw64 with your install path
+	res = strings.Replace(res, "/mingw64", "", -1)
 	return res
 }

--- a/settings.go
+++ b/settings.go
@@ -25,7 +25,7 @@ func configDir() (string, error) {
 	case "darwin":
 		path = os.ExpandEnv("$HOME/Library/Application Support/Code/User/")
 	case "windows":
-		path = os.ExpandEnv("/c/Users/$USERNAME/AppData/Roaming/Code/User")
+		path = os.ExpandEnv("/Users/$USERNAME/AppData/Roaming/Code/User")
 	default:
 		return "", xerrors.Errorf("unsupported platform: %s", runtime.GOOS)
 	}
@@ -42,7 +42,7 @@ func extensionsDir() (string, error) {
 	case "linux", "darwin":
 		path = os.ExpandEnv("$HOME/.vscode/extensions/")
 	case "windows":
-		path = os.ExpandEnv("/c/Users/$USERNAME/.vscode/extensions/")
+		path = os.ExpandEnv("/Users/$USERNAME/.vscode/extensions/")
 	default:
 		return "", xerrors.Errorf("unsupported platform: %s", runtime.GOOS)
 	}

--- a/settings.go
+++ b/settings.go
@@ -25,7 +25,7 @@ func configDir() (string, error) {
 	case "darwin":
 		path = os.ExpandEnv("$HOME/Library/Application Support/Code/User/")
 	case "windows":
-		path = os.ExpandEnv("/Users/$USERNAME/AppData/Roaming/Code/User")
+		return gitbashWindowsDir(os.ExpandEnv("/Users/$USERNAME/AppData/Roaming/Code/User")), nil
 	default:
 		return "", xerrors.Errorf("unsupported platform: %s", runtime.GOOS)
 	}
@@ -42,7 +42,7 @@ func extensionsDir() (string, error) {
 	case "linux", "darwin":
 		path = os.ExpandEnv("$HOME/.vscode/extensions/")
 	case "windows":
-		path = os.ExpandEnv("/Users/$USERNAME/.vscode/extensions/")
+		return gitbashWindowsDir(os.ExpandEnv("/Users/$USERNAME/.vscode/extensions/")), nil
 	default:
 		return "", xerrors.Errorf("unsupported platform: %s", runtime.GOOS)
 	}

--- a/settings.go
+++ b/settings.go
@@ -24,6 +24,8 @@ func configDir() (string, error) {
 		path = os.ExpandEnv("$HOME/.config/Code/User/")
 	case "darwin":
 		path = os.ExpandEnv("$HOME/Library/Application Support/Code/User/")
+	case "windows":
+		path = os.ExpandEnv("/c/Users/$USERNAME/AppData/Roaming/Code/User")
 	default:
 		return "", xerrors.Errorf("unsupported platform: %s", runtime.GOOS)
 	}
@@ -39,6 +41,8 @@ func extensionsDir() (string, error) {
 	switch runtime.GOOS {
 	case "linux", "darwin":
 		path = os.ExpandEnv("$HOME/.vscode/extensions/")
+	case "windows":
+		path = os.ExpandEnv("/c/Users/$USERNAME/.vscode/extensions/")
 	default:
 		return "", xerrors.Errorf("unsupported platform: %s", runtime.GOOS)
 	}

--- a/settings.go
+++ b/settings.go
@@ -25,7 +25,7 @@ func configDir() (string, error) {
 	case "darwin":
 		path = os.ExpandEnv("$HOME/Library/Application Support/Code/User/")
 	case "windows":
-		return gitbashWindowsDir(os.ExpandEnv("/Users/$USERNAME/AppData/Roaming/Code/User")), nil
+		return gitbashWindowsDir(os.ExpandEnv("/c/Users/$USERNAME/AppData/Roaming/Code/User")), nil
 	default:
 		return "", xerrors.Errorf("unsupported platform: %s", runtime.GOOS)
 	}
@@ -42,7 +42,7 @@ func extensionsDir() (string, error) {
 	case "linux", "darwin":
 		path = os.ExpandEnv("$HOME/.vscode/extensions/")
 	case "windows":
-		return gitbashWindowsDir(os.ExpandEnv("/Users/$USERNAME/.vscode/extensions/")), nil
+		return gitbashWindowsDir(os.ExpandEnv("/c/Users/$USERNAME/.vscode/extensions/")), nil
 	default:
 		return "", xerrors.Errorf("unsupported platform: %s", runtime.GOOS)
 	}

--- a/sshcode.go
+++ b/sshcode.go
@@ -239,7 +239,7 @@ func openBrowser(url string) {
 	const (
 		macPath  = "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
 		wslPath  = "/mnt/c/Program Files (x86)/Google/Chrome/Application/chrome.exe"
-		msysPath = "/c/Program Files (x86)/Google/Chrome/Application/chrome.exe"
+		msysPath = "/Program Files (x86)/Google/Chrome/Application/chrome.exe"
 	)
 
 	switch {

--- a/sshcode.go
+++ b/sshcode.go
@@ -200,9 +200,9 @@ func expandPath(path string) string {
 	// string with the homedir as having a tilde in the middle of a filename is valid.
 	homedir := os.Getenv("HOME")
 	if homedir != "" {
-		if path == "$HOME" {
+		if path == "~" {
 			path = homedir
-		} else if strings.HasPrefix(path, "$HOME/") {
+		} else if strings.HasPrefix(path, "~/") {
 			path = filepath.Join(homedir, path[2:])
 		}
 	}
@@ -423,7 +423,7 @@ func syncUserSettings(sshFlags string, host string, back bool) error {
 		return err
 	}
 
-	const remoteSettingsDir = "$HOME/.local/share/code-server/User/"
+	const remoteSettingsDir = "~/.local/share/code-server/User/"
 
 	var (
 		src  = localConfDir + "/"
@@ -449,7 +449,7 @@ func syncExtensions(sshFlags string, host string, back bool) error {
 		return err
 	}
 
-	const remoteExtensionsDir = "$HOME/.local/share/code-server/extensions/"
+	const remoteExtensionsDir = "~/.local/share/code-server/extensions/"
 
 	var (
 		src  = localExtensionsDir + "/"

--- a/sshcode.go
+++ b/sshcode.go
@@ -28,7 +28,7 @@ const (
 	sshControlPath             = sshDirectory + "/control-%h-%p-%r"
 )
 
-type options struct {
+type options struct { 
 	skipSync        bool
 	syncBack        bool
 	noOpen          bool
@@ -239,6 +239,7 @@ func openBrowser(url string) {
 	const (
 		macPath = "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
 		wslPath = "/mnt/c/Program Files (x86)/Google/Chrome/Application/chrome.exe"
+		msysPath = "/c/Program Files (x86)/Google/Chrome/Application/chrome.exe"
 	)
 
 	switch {
@@ -254,6 +255,8 @@ func openBrowser(url string) {
 		openCmd = exec.Command(macPath, chromeOptions(url)...)
 	case pathExists(wslPath):
 		openCmd = exec.Command(wslPath, chromeOptions(url)...)
+	case pathExists(msysPath):
+		openCmd = exec.Command(msysPath, chromeOptions(url)...)
 	default:
 		err := browser.OpenURL(url)
 		if err != nil {

--- a/sshcode.go
+++ b/sshcode.go
@@ -28,7 +28,7 @@ const (
 	sshControlPath             = sshDirectory + "/control-%h-%p-%r"
 )
 
-type options struct { 
+type options struct {
 	skipSync        bool
 	syncBack        bool
 	noOpen          bool
@@ -237,12 +237,14 @@ func openBrowser(url string) {
 	var openCmd *exec.Cmd
 
 	const (
-		macPath = "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
-		wslPath = "/mnt/c/Program Files (x86)/Google/Chrome/Application/chrome.exe"
+		macPath  = "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+		wslPath  = "/mnt/c/Program Files (x86)/Google/Chrome/Application/chrome.exe"
 		msysPath = "/c/Program Files (x86)/Google/Chrome/Application/chrome.exe"
 	)
 
 	switch {
+	case commandExists("chrome"):
+		openCmd = exec.Command("chrome", chromeOptions(url)...)
 	case commandExists("google-chrome"):
 		openCmd = exec.Command("google-chrome", chromeOptions(url)...)
 	case commandExists("google-chrome-stable"):

--- a/sshcode.go
+++ b/sshcode.go
@@ -245,8 +245,6 @@ func openBrowser(url string) {
 	switch {
 	case commandExists("chrome"):
 		openCmd = exec.Command("chrome", chromeOptions(url)...)
-	case commandExists("chrome.exe"):
-		openCmd = exec.Command("chrome.exe", chromeOptions(url)...)
 	case commandExists("google-chrome"):
 		openCmd = exec.Command("google-chrome", chromeOptions(url)...)
 	case commandExists("google-chrome-stable"):

--- a/sshcode.go
+++ b/sshcode.go
@@ -423,7 +423,7 @@ func syncUserSettings(sshFlags string, host string, back bool) error {
 		return err
 	}
 
-	const remoteSettingsDir = "~/.local/share/code-server/User/"
+	const remoteSettingsDir = ".local/share/code-server/User/"
 
 	var (
 		src  = localConfDir + "/"
@@ -449,7 +449,7 @@ func syncExtensions(sshFlags string, host string, back bool) error {
 		return err
 	}
 
-	const remoteExtensionsDir = "~/.local/share/code-server/extensions/"
+	const remoteExtensionsDir = ".local/share/code-server/extensions/"
 
 	var (
 		src  = localExtensionsDir + "/"
@@ -496,7 +496,7 @@ func downloadScript(codeServerPath string) string {
 
 [ "$(uname -m)" != "x86_64" ] && echo "Unsupported server architecture $(uname -m). code-server only has releases for x86_64 systems." && exit 1
 pkill -f %v || true
-mkdir -p ~/.local/share/code-server %v
+mkdir -p $HOME/.local/share/code-server %v
 cd %v
 curlflags="-o latest-linux"
 if [ -f latest-linux ]; then

--- a/sshcode.go
+++ b/sshcode.go
@@ -245,6 +245,8 @@ func openBrowser(url string) {
 	switch {
 	case commandExists("chrome"):
 		openCmd = exec.Command("chrome", chromeOptions(url)...)
+	case commandExists("chrome.exe"):
+		openCmd = exec.Command("chrome.exe", chromeOptions(url)...)
 	case commandExists("google-chrome"):
 		openCmd = exec.Command("google-chrome", chromeOptions(url)...)
 	case commandExists("google-chrome-stable"):


### PR DESCRIPTION
EDIT: OLD IMAGES HAVE BEEN REDUCED TO LINKS TO SAVE POST SPACE

Basically, I have made `sshcode` run properly on `msys/mingw` enviroments, 
## TL;DR
* Chrome only works when using `msys`/`cygwin` based enviroments
* sshcode only works in `msys`/`cygwin` based enviroments
* sshcode in `cmd.exe` does not work yet due to how sshcode calls `ssh`


Summary of my edits
* `main.go` > Added filepath conversion, (thanks @eargollo )
* `settings.go` > added default paths for VSCode data on windows
* `sshcode.go` > copied and slightly tweaked the `wslPath` to match a `windows` enviroment for accessing the `C:\` drive.

### TODO
* 100% windows support: NOTE, I do not plan on implementing this for the time being, i feel like i have dont enought to make a great step towards windows support, this todo will be a log of the errors in windows
     * Some odd bug where it returns this when running with `cmd.exe`
     * The error appears to be sshcode not actually executing `ssh` on windows even if it is in `%path%`
          * This appears to be because of  how `sshcode` calls the `ssh` command
```
C:\Misc\MegaSync\Code\Workspace\sshcode>go build

C:\Misc\MegaSync\Code\Workspace\sshcode>sshcode.exe --skipsync merith@192.168.0.101
2019-07-29 20:58:13 [94mINFO[0m       failed to stat ~/.ssh directory, disabling connection reuse feature: CreateFile ~\.ssh: The system cannot find the path specified.
2019-07-29 20:58:13 [94mINFO[0m       ensuring code-server is updated...
2019-07-29 20:58:13 [31mFATAL[0m      error: failed to update code-server:
---ssh cmd---
ssh  merith@192.168.0.101 '/usr/bin/env bash -l'
---download script---
set -euxo pipefail || exit 1

[ "$(uname -m)" != "x86_64" ] && echo "Unsupported server architecture $(uname -m). code-server only has releases for x86_64 systems." && exit 1
pkill -f ~/.cache/sshcode/sshcode-server || true
mkdir -p ~/.local/share/code-server ~\.cache\sshcode
cd ~\.cache\sshcode
curlflags="-o latest-linux"
if [ -f latest-linux ]; then
        curlflags="$curlflags -z latest-linux"
fi
curl $curlflags https://codesrv-ci.cdr.sh/latest-linux
[ -f ~/.cache/sshcode/sshcode-server ] && rm ~/.cache/sshcode/sshcode-server
ln latest-linux ~/.cache/sshcode/sshcode-server
chmod +x ~/.cache/sshcode/sshcode-server: exec: "sh": executable file not found in %PATH%
```

attached image is of it building and running (first working release,)
https://user-images.githubusercontent.com/10422110/61765201-ef1c0e80-ad90-11e9-87cb-b46e6dc2a909.gif

This image is of the second build working just fine, Note, yes i did have to drag the window over from the side, that is because i have two monitors, and for some reason my mouse wasnt recorded so... thats a thing
https://user-images.githubusercontent.com/10422110/62153007-8533c580-b2b8-11e9-9d2b-03e25af9bbd0.gif

8-9-2019, 1211 `-7PST`
This build has the sshMaster fix (i didnt bother building it again just for the example as it would take FOREVER as seen in previous pictures, and sorry for horrible quality,)
https://user-images.githubusercontent.com/10422110/62803352-094b3180-ba9f-11e9-818f-4c4b93fb60ed.gif

8-9-2019, 1308 `-7PST`
this build is a work in progress, some users may have to modify `main.go` to match their setups. otherwise `sshcode --skipsync user@server /<choosen filepath>` works. In the example i open `/opt` on the server 
https://user-images.githubusercontent.com/10422110/62806173-f50b3280-baa6-11e9-8438-71a5aa6d7104.gif

8-9-2019, 1358 `-7PST`
Not going to upload gif, would take to long, but rsync now works provided its installed and in path
UPDATE: DESPITE WHAT TRAVIS SAYS, IT WORKS, AND BUILDS JUST FINE