### PR TITLE
Add ability to upload local binary

### DIFF
--- a/main.go
+++ b/main.go
@@ -41,6 +41,7 @@ type rootCmd struct {
 	noReuseConnection bool
 	bindAddr          string
 	sshFlags          string
+	codeServerPath    string
 }
 
 func (c *rootCmd) Spec() cli.CommandSpec {
@@ -58,6 +59,7 @@ func (c *rootCmd) RegisterFlags(fl *pflag.FlagSet) {
 	fl.BoolVar(&c.noReuseConnection, "no-reuse-connection", false, "do not reuse SSH connection via control socket")
 	fl.StringVar(&c.bindAddr, "bind", "", "local bind address for SSH tunnel, in [HOST][:PORT] syntax (default: 127.0.0.1)")
 	fl.StringVar(&c.sshFlags, "ssh-flags", "", "custom SSH flags")
+	fl.StringVar(&c.codeServerPath, "code-server-path", "", "custom code-server binary to upload")
 }
 
 func (c *rootCmd) Run(fl *pflag.FlagSet) {
@@ -84,6 +86,7 @@ func (c *rootCmd) Run(fl *pflag.FlagSet) {
 		bindAddr:        c.bindAddr,
 		syncBack:        c.syncBack,
 		reuseConnection: !c.noReuseConnection,
+		codeServerPath:  c.codeServerPath,
 	})
 
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -41,7 +41,7 @@ type rootCmd struct {
 	noReuseConnection bool
 	bindAddr          string
 	sshFlags          string
-	codeServerPath    string
+	uploadCodeServer  string
 }
 
 func (c *rootCmd) Spec() cli.CommandSpec {
@@ -59,7 +59,7 @@ func (c *rootCmd) RegisterFlags(fl *pflag.FlagSet) {
 	fl.BoolVar(&c.noReuseConnection, "no-reuse-connection", false, "do not reuse SSH connection via control socket")
 	fl.StringVar(&c.bindAddr, "bind", "", "local bind address for SSH tunnel, in [HOST][:PORT] syntax (default: 127.0.0.1)")
 	fl.StringVar(&c.sshFlags, "ssh-flags", "", "custom SSH flags")
-	fl.StringVar(&c.codeServerPath, "code-server-path", "", "custom code-server binary to upload")
+	fl.StringVar(&c.uploadCodeServer, "upload-code-server", "", "custom code-server binary to upload to the remote host")
 }
 
 func (c *rootCmd) Run(fl *pflag.FlagSet) {
@@ -81,12 +81,12 @@ func (c *rootCmd) Run(fl *pflag.FlagSet) {
 	}
 
 	err := sshCode(host, dir, options{
-		skipSync:        c.skipSync,
-		sshFlags:        c.sshFlags,
-		bindAddr:        c.bindAddr,
-		syncBack:        c.syncBack,
-		reuseConnection: !c.noReuseConnection,
-		codeServerPath:  c.codeServerPath,
+		skipSync:         c.skipSync,
+		sshFlags:         c.sshFlags,
+		bindAddr:         c.bindAddr,
+		syncBack:         c.syncBack,
+		reuseConnection:  !c.noReuseConnection,
+		uploadCodeServer: c.uploadCodeServer,
 	})
 
 	if err != nil {

--- a/sshcode.go
+++ b/sshcode.go
@@ -29,14 +29,14 @@ const (
 )
 
 type options struct {
-	skipSync        bool
-	syncBack        bool
-	noOpen          bool
-	reuseConnection bool
-	bindAddr        string
-	remotePort      string
-	sshFlags        string
-	codeServerPath  string
+	skipSync         bool
+	syncBack         bool
+	noOpen           bool
+	reuseConnection  bool
+	bindAddr         string
+	remotePort       string
+	sshFlags         string
+	uploadCodeServer string
 }
 
 func sshCode(host, dir string, o options) error {
@@ -78,9 +78,9 @@ func sshCode(host, dir string, o options) error {
 	}
 
 	// Upload local code-server or download code-server from CI server.
-	if o.codeServerPath != "" {
+	if o.uploadCodeServer != "" {
 		flog.Info("uploading local code-server binary...")
-		err = copyCodeServerBinary(o.sshFlags, host, o.codeServerPath, codeServerPath)
+		err = copyCodeServerBinary(o.sshFlags, host, o.uploadCodeServer, codeServerPath)
 		if err != nil {
 			return xerrors.Errorf("failed to upload local code-server binary to remote server: %w", err)
 		}
@@ -428,7 +428,7 @@ func checkSSHMaster(sshMasterCmd *exec.Cmd, sshFlags string, host string) error 
 
 // copyCodeServerBinary copies a code-server binary from local to remote.
 func copyCodeServerBinary(sshFlags string, host string, localPath string, remotePath string) error {
-	if err := ensureFile(localPath); err != nil {
+	if err := validateIsFile(localPath); err != nil {
 		return err
 	}
 
@@ -558,8 +558,8 @@ func ensureDir(path string) error {
 	return nil
 }
 
-// ensureFile tries to stat the specified path and ensure it's a file.
-func ensureFile(path string) error {
+// validateIsFile tries to stat the specified path and ensure it's a file.
+func validateIsFile(path string) error {
 	info, err := os.Stat(path)
 	if err != nil {
 		return err


### PR DESCRIPTION
Adds `--code-server-path` flag that accepts a path to a file on the local machine. It will be uploaded to the code-server path on the remote server instead of the download script being executed.

There is no verification of the local binary, so a user could upload something that isn't a code-server binary or a custom binary or something else along those lines.

This allows remote servers with no internet access to have a code-server binary uploaded to them, which is useful for extremely secure environments.

Closes #73.