### PR TITLE
Fixed allow-http-warning and no auth

### DIFF
--- a/sshcode.go
+++ b/sshcode.go
@@ -145,7 +145,7 @@ func sshCode(host, dir string, o options) error {
 	flog.Info("Tunneling remote port %v to %v", o.remotePort, o.bindAddr)
 
 	sshCmdStr :=
-		fmt.Sprintf("ssh -tt -q -L %v:localhost:%v %v %v 'cd %v; %v --host 127.0.0.1 --allow-http --no-auth --port=%v'",
+		fmt.Sprintf("ssh -tt -q -L %v:localhost:%v %v %v 'cd %v; %v --host 127.0.0.1 --auth none --port=%v'",
 			o.bindAddr, o.remotePort, o.sshFlags, host, dir, codeServerPath, o.remotePort,
 		)
 


### PR DESCRIPTION
Fixed:
- --allow-http warning: no such option
- changed --no-auth to --auth none
to represent the changes in the newest code-server version