### PR TITLE
Remove duplicated word from sync user settings error

### DIFF
--- a/sshcode.go
+++ b/sshcode.go
@@ -212,7 +212,7 @@ func sshCode(host, dir string, o options) error {
 
 	err = syncUserSettings(o.sshFlags, host, true)
 	if err != nil {
-		return xerrors.Errorf("failed to sync user settings settings back: %w", err)
+		return xerrors.Errorf("failed to sync user settings back: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
A minor fix to an error, where ``settings`` was a repeated word.
``failed to sync user settings settings back`` -> ``failed to sync user settings back``