### PR TITLE
Add electron support

### DIFF
--- a/sshcode.go
+++ b/sshcode.go
@@ -269,6 +269,8 @@ func openBrowser(url string) {
 	)
 
 	switch {
+	case commandExists("electron"):
+		openCmd = exec.Command("electron", url)
 	case commandExists("google-chrome"):
 		openCmd = exec.Command("google-chrome", chromeOptions(url)...)
 	case commandExists("google-chrome-stable"):


### PR DESCRIPTION
This adds the `electron` binary into the `commandExists` check switch in `sshcode.go`, and if electron is found, use it.

This idea works because that means that certain extenstions such as adblockers, (or in braves case, the built in blocker which is enabled even when extenstions are not)